### PR TITLE
Add support date and time format

### DIFF
--- a/src/Faker.php
+++ b/src/Faker.php
@@ -169,7 +169,9 @@ final class Faker
             // Date representation, without time.
             case 'date':
                 return DateTime::dateTime()->format('Y-m-d');
-            // Internet email address, see RFC 5322, section 3.4.1.
+            // Time representation.
+            case 'time':
+                return DateTime::dateTime()->format('H:i:s');
             case 'email':
                 return $this->getInternetFakerInstance()->safeEmail();
             // Internet host name, see RFC 1034, section 3.1.

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -166,6 +166,9 @@ final class Faker
             // Date representation, as defined by RFC 3339, section 5.6.
             case 'date-time':
                 return DateTime::dateTime()->format(DATE_RFC3339);
+            // Date representation, without time.
+            case 'date':
+                return DateTime::dateTime()->format('Y-m-d');
             // Internet email address, see RFC 5322, section 3.4.1.
             case 'email':
                 return $this->getInternetFakerInstance()->safeEmail();

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -131,6 +131,7 @@ class HelperTest extends TestCase
         return [
             ['date-time'],
             ['date'],
+            ['time'],
             ['email'],
             ['hostname'],
             ['ipv4'],

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -130,6 +130,7 @@ class HelperTest extends TestCase
     {
         return [
             ['date-time'],
+            ['date'],
             ['email'],
             ['hostname'],
             ['ipv4'],

--- a/tests/fixture/format.json
+++ b/tests/fixture/format.json
@@ -13,6 +13,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
     "email": {
       "type": "string",
       "format": "email"

--- a/tests/fixture/format.json
+++ b/tests/fixture/format.json
@@ -2,6 +2,8 @@
   "type": "object",
   "required": [
     "date-time",
+    "date",
+    "time",
     "email",
     "hostname",
     "ipv4",
@@ -16,6 +18,10 @@
     "date": {
       "type": "string",
       "format": "date"
+    },
+    "time": {
+      "type": "string",
+      "format": "time"
     },
     "email": {
       "type": "string",

--- a/tests/fixture/string.json
+++ b/tests/fixture/string.json
@@ -9,6 +9,7 @@
     "typeAndPattern",
     "typeAndFormat(date-time)",
     "typeAndFormat(date)",
+    "typeAndFormat(time)",
     "typeAndFormat(email)",
     "typeAndFormat(hostname)",
     "typeAndFormat(ipv4)",
@@ -47,6 +48,10 @@
     "typeAndFormat(date)": {
       "type": "string",
       "format": "date"
+    },
+    "typeAndFormat(time)": {
+      "type": "string",
+      "format": "time"
     },
     "typeAndFormat(email)": {
       "type": "string",

--- a/tests/fixture/string.json
+++ b/tests/fixture/string.json
@@ -8,6 +8,7 @@
     "typeAndMinLengthAndMaxLength",
     "typeAndPattern",
     "typeAndFormat(date-time)",
+    "typeAndFormat(date)",
     "typeAndFormat(email)",
     "typeAndFormat(hostname)",
     "typeAndFormat(ipv4)",
@@ -42,6 +43,10 @@
     "typeAndFormat(date-time)": {
       "type": "string",
       "format": "date-time"
+    },
+    "typeAndFormat(date)": {
+      "type": "string",
+      "format": "date"
     },
     "typeAndFormat(email)": {
       "type": "string",


### PR DESCRIPTION
以下のフォーマットのサポートを追加しました。

* 時間なしの日付フォーマット `"format": "date"` 
* 時間フォーマット `"format": "time"`

https://json-schema.org/understanding-json-schema/reference/string#dates-and-times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced date and time formatting options have been added, allowing for more versatile data generation.
	- New properties for date and time formats included in the JSON schema to support additional validation.

- **Bug Fixes**
	- Improved functionality of existing methods to accommodate new date and time formats, ensuring accurate data handling.

- **Documentation**
	- Updated JSON schemas to reflect new format types for better clarity in data validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->